### PR TITLE
Fix Funkload WF_fetch patch to handle cookies correctly.

### DIFF
--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -323,7 +323,7 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
     cookie_list = []
     for domain, cookies in self.cookies.items():
         # check cookie domain
-        if not server.endswith(domain):
+        if not server.endswith(domain) and domain[1:] != server:
             continue
         for path, cookies in cookies.items():
             # check that the path matches


### PR DESCRIPTION
Currently FunkLoad ignores all cookies that has a leading '.' as domain.
It's necessary to add this other check as webutil does for cookies with a leading '.' [1]

[1] https://github.com/osde8info/webunit/blob/master/webunit/cookie.py#L75
