### PR TITLE
Added support for providing the test configuration file with --config parameter

### DIFF
--- a/doc/source/usage-fl-run-bench.rst
+++ b/doc/source/usage-fl-run-bench.rst
@@ -14,6 +14,8 @@ Examples
 --------
   fl-run-bench myFile.py MyTestCase.testSomething
                         Bench MyTestCase.testSomething using MyTestCase.conf.
+  fl-run-bench --config ~/test.conf myFile.py MyTestCase.testSomething
+                        Bench MyTestCase.testSomething using test.conf located in home directory.
   fl-run-bench -u http://localhost:8080 -c 10:20 -D 30 myFile.py \
       MyTestCase.testSomething
                         Bench MyTestCase.testSomething on localhost:8080
@@ -27,6 +29,10 @@ Options
 
 --version               show program's version number and exit
 --help, -h              show this help message and exit
+--config=CONFIG
+                        Path to alternative config location. Otherwise the configuration file is
+                        expected to be named after test case class, located either next to test module or path
+                        defined by environment variable ``FL_CONF_PATH``
 --url=MAIN_URL, -u MAIN_URL
                         Base URL to bench.
 --cycles=BENCH_CYCLES, -c BENCH_CYCLES

--- a/doc/source/usage-fl-run-test.rst
+++ b/doc/source/usage-fl-run-test.rst
@@ -49,6 +49,10 @@ Options
 ---------
 --version               show program's version number and exit
 --help, -h              show this help message and exit
+--config=CONFIG
+                        Path to alternative config location. Otherwise the configuration file is
+                        expected to be named after test case class, located either next to test module or path
+                        defined by environment variable ``FL_CONF_PATH``
 --quiet, -q             Minimal output.
 --verbose, -v           Verbose output.
 --debug, -d             FunkLoad and doctest debug output.

--- a/src/funkload/BenchRunner.py
+++ b/src/funkload/BenchRunner.py
@@ -592,6 +592,11 @@ def main(args=sys.argv[1:]):
 
     parser = OptionParser(USAGE, formatter=TitledHelpFormatter(),
                           version="FunkLoad %s" % get_version())
+    parser.add_option("", "--config",
+                      type="string",
+                      dest="config",
+                      metavar='CONFIG',
+                      help="Path to alternative config file")
     parser.add_option("-u", "--url",
                       type="string",
                       dest="main_url",

--- a/src/funkload/FunkLoadTestCase.py
+++ b/src/funkload/FunkLoadTestCase.py
@@ -108,10 +108,12 @@ class FunkLoadTestCase(unittest.TestCase):
     def _funkload_init(self):
         """Initialize a funkload test case using a configuration file."""
         # look into configuration file
-        config_directory = os.getenv('FL_CONF_PATH', '.')
-        config_path = os.path.join(config_directory,
-                                   self.__class__.__name__ + '.conf')
-        config_path = os.path.abspath(config_path)
+        config_path = getattr(self._options, 'config', None)
+        if not config_path:
+          config_directory = os.getenv('FL_CONF_PATH', '.')
+          config_path = os.path.join(config_directory,
+                                     self.__class__.__name__ + '.conf')
+        config_path = os.path.abspath(os.path.expanduser(config_path))
         if not os.path.exists(config_path):
             config_path = "Missing: "+ config_path
         config = ConfigParser()

--- a/src/funkload/TestRunner.py
+++ b/src/funkload/TestRunner.py
@@ -371,6 +371,8 @@ Examples
         global g_doctest_verbose
         parser = OptionParser(self.USAGE, formatter=TitledHelpFormatter(),
                               version="FunkLoad %s" % get_version())
+        parser.add_option("", "--config", type="string", dest="config", metavar='CONFIG',
+                          help="Path to alternative config file.")
         parser.add_option("-q", "--quiet", action="store_true",
                           help="Minimal output.")
         parser.add_option("-v", "--verbose", action="store_true",


### PR DESCRIPTION
- Adds new parameter to fl-run-bench and fl-run-test executables: --config
- Not using short parameter option "-c" because of conflicting with --cycles/-c
- Updated documentation accordingly

---

**Reasoning for the change**: 
- If find it limiting use configuration files named after the class. One may want to have named them after setup
- I wasn't aware of FL_CONF_PATH environment variable until opened the source code. Providing a parameter is much easier to find and use
