### PR TITLE
implicit patching so we have lightweight threads - fixes #67

### DIFF
--- a/src/funkload/__init__.py
+++ b/src/funkload/__init__.py
@@ -20,3 +20,10 @@
 
 $Id: __init__.py 24649 2005-08-29 14:20:19Z bdelbosc $
 """
+
+# if gevent is present, patch the stdlib so we speed things up
+try:
+    from gevent.monkey import patch_all
+    patch_all()
+except ImportError:
+    pass


### PR DESCRIPTION
This just calls gevent momkey patching function, so we use greenlets instead of using threads. The immediate effect is that Funkload is much more lightweight when you run > 500 threads per node for example

I have tried this on various projects and I did not encounter any issue
