### PR TITLE
workaround for https://github.com/pypa/virtualenv/issues/330

### DIFF
--- a/src/funkload/Distributed.py
+++ b/src/funkload/Distributed.py
@@ -459,6 +459,10 @@ class DistributionMgr(threading.Thread):
                 cwdir=remote_res_dir)
             worker.execute("rm %s" % remote_tarball)
 
+            # workaround for https://github.com/pypa/virtualenv/issues/330
+            worker.execute("rm lib64", cwdir=virtual_env)
+            worker.execute("ln -s lib lib64", cwdir=virtual_env)
+
         threads = []
         trace("* Preparing sandboxes for %d workers." % len(self._workers))
         for worker in list(self._workers):


### PR DESCRIPTION
If you run Funkload in distributed mode on a 64bits centos-like distribution, Virtualenv does a symlib from lib->lib64 in the virtualenv root.

The problem is that it uses '.' as the root directory, and when you call this command through ssh, it's replaced by the current working directory of the original host. 

IOW you get a broken symlink. The immediate impact is that the virtualenv will not see packages that were installed locally. For instance a custom funkload snapshot.

This commit is a workaround until virtualenv is fixed. It just replaces the lib64 broken symlink by a new working one
