### PR TITLE
handle empty results or stats

### DIFF
--- a/src/funkload/Distributed.py
+++ b/src/funkload/Distributed.py
@@ -659,6 +659,9 @@ class DistributionMgr(threading.Thread):
             fd.write("</funkload>\n")
 
     def _calculate_time_skew(self, results, stats):
+        if not results or not stats:
+            return 1
+
         def min_time(vals):
             keyfunc = lambda elem: float(elem.attrib['time'])
             return keyfunc(min(vals, key=keyfunc))


### PR DESCRIPTION
Fixes #38

AFAICT the ratio returned from this method is used in one place, as a multiplier

So... if either the stats or results are empty we just return `1` as an identity ratio

This allows report generation to complete successfully
