### PR TITLE
Fix log_to

### DIFF
--- a/src/funkload/TestRunner.py
+++ b/src/funkload/TestRunner.py
@@ -450,8 +450,6 @@ Examples
             options.ftest_debug_level = 1
             options.ftest_log_to = 'console file'
             g_doctest_verbose = True
-        else:
-            options.ftest_log_to = 'file'
         if options.debug_level:
             options.ftest_debug_level = int(options.debug_level)
         if sys.platform.lower().startswith('win'):


### PR DESCRIPTION
I tried setting "log_to = console", but fl-run-test was ALWAYS
putting the output in a log file.  I found the problem was that
the "option" was always being set and therefore clobbering what
was in the conf file.
