### PR TITLE
PatchWebUnit-Fix

### DIFF
--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -386,7 +386,9 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
     # Other Full Request headers
     if self.authinfo:
         headers.append(('Authorization', "Basic %s"%self.authinfo))
-    if not webproxy:
+        
+    #If a value is specified for 'Host' then another value should not be appended
+    if not webproxy and not 'Host' in self.extra_headers.keys():
         # HTTPConnection seems to add a host header itself.
         # So we only need to do this if we are not using a proxy.
         headers.append(('Host', host_header))


### PR DESCRIPTION
This fixes the issue where if a value is specified for 'Host' in the header, it is not being used, because there is another one being set.