### PR TITLE
Fix wrong Host header detection

### DIFF
--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -388,7 +388,7 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
         headers.append(('Authorization', "Basic %s"%self.authinfo))
         
     #If a value is specified for 'Host' then another value should not be appended
-    if not webproxy and not 'Host' in self.extra_headers.keys():
+    if not webproxy and 'Host' not in self.extra_headers:
         # HTTPConnection seems to add a host header itself.
         # So we only need to do this if we are not using a proxy.
         headers.append(('Host', host_header))

--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -388,7 +388,7 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
         headers.append(('Authorization', "Basic %s"%self.authinfo))
         
     #If a value is specified for 'Host' then another value should not be appended
-    if not webproxy and 'Host' not in self.extra_headers:
+    if not webproxy and 'Host' not in dict(self.extra_headers):
         # HTTPConnection seems to add a host header itself.
         # So we only need to do this if we are not using a proxy.
         headers.append(('Host', host_header))


### PR DESCRIPTION
after update my funkload test is broken with errror

File "/usr/local/lib/python2.7/dist-packages/funkload/PatchWebunit.py", line 391, in WF_fetch
if not webproxy and not 'Host' in self.extra_headers.keys():
AttributeError: 'list' object has no attribute 'keys'
