### PR TITLE
Correct "Host" header test

### DIFF
--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -387,7 +387,9 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
     if self.authinfo:
         headers.append(('Authorization', "Basic %s"%self.authinfo))
 
-    #If a value is specified for 'Host' then another value should not be appended
+    # If a value is specified for 'Host' then another value should not be appended.
+    # self.extra_headers is a list of tuples, convert to dictionary to make the
+    # test work.
     if not webproxy and not 'Host' in dict(self.extra_headers):
         # HTTPConnection seems to add a host header itself.
         # So we only need to do this if we are not using a proxy.

--- a/src/funkload/PatchWebunit.py
+++ b/src/funkload/PatchWebunit.py
@@ -386,9 +386,9 @@ def WF_fetch(self, url, postdata=None, server=None, port=None, protocol=None,
     # Other Full Request headers
     if self.authinfo:
         headers.append(('Authorization', "Basic %s"%self.authinfo))
-        
+
     #If a value is specified for 'Host' then another value should not be appended
-    if not webproxy and not 'Host' in self.extra_headers.keys():
+    if not webproxy and not 'Host' in dict(self.extra_headers):
         # HTTPConnection seems to add a host header itself.
         # So we only need to do this if we are not using a proxy.
         headers.append(('Host', host_header))
@@ -539,4 +539,3 @@ def HR___repr__(self):
         self.message)
 
 HTTPResponse.__repr__ = HR___repr__
-


### PR DESCRIPTION
The test to see if 'Host' header already exists is not correct. To make the test work convert list of tuples representing the current headers to a dictionary, so we can check for presence of 'Host' header.
